### PR TITLE
Add Terraform code to manage Google Workspace Admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,57 @@
 # Terraform Organization
+
+## Google Workspace Admin Management
+
+This repository contains Terraform code to manage Google Workspace Admin, create accounts from a CSV file, associate them with email groups, and manage shared drives.
+
+### Prerequisites
+
+- Terraform installed on your machine
+- Google Cloud SDK installed and configured
+- Google Workspace Admin API enabled
+- Service account with necessary permissions
+
+### Usage
+
+1. Clone the repository:
+
+   ```sh
+   git clone https://github.com/codaqui/terraform-organization.git
+   cd terraform-organization
+   ```
+
+2. Initialize Terraform:
+
+   ```sh
+   terraform init
+   ```
+
+3. Create a `terraform.tfvars` file and provide the necessary input variables:
+
+   ```hcl
+   csv_file_path = "path/to/your/csvfile.csv"
+   email_groups  = ["group1@example.com", "group2@example.com"]
+   shared_drives = ["Shared Drive 1", "Shared Drive 2"]
+   ```
+
+4. Apply the Terraform configuration:
+
+   ```sh
+   terraform apply
+   ```
+
+### Creating Accounts from a CSV File
+
+The Terraform code reads and parses the CSV file specified in the `csv_file_path` variable. The CSV file should contain the following columns: `first_name`, `last_name`, and `personal_email`. The code will create user accounts in Google Workspace Admin based on the parsed CSV data.
+
+### Associating Accounts with Email Groups
+
+The Terraform code associates the created user accounts with the email groups specified in the `email_groups` variable. Ensure that the email groups already exist in your Google Workspace Admin.
+
+### Managing Shared Drives
+
+The Terraform code manages the shared drives specified in the `shared_drives` variable. It will create and configure the shared drives and associate the created user accounts with the shared drives.
+
+### Ensuring User Passwords are Sent Only to Personal Email
+
+The Terraform code ensures that user passwords are sent only to their personal email addresses specified in the CSV file. This is done by using the `personal_email` field from the CSV file to send the password to the user's personal email address.

--- a/csv_import.tf
+++ b/csv_import.tf
@@ -1,0 +1,24 @@
+data "external" "csv_data" {
+  program = ["python3", "${path.module}/scripts/read_csv.py", var.csv_file_path]
+}
+
+resource "googleworkspace_user" "users" {
+  for_each = { for user in data.external.csv_data.result : user["personal_email"] => user }
+
+  primary_email = each.value["personal_email"]
+  name {
+    given_name  = each.value["first_name"]
+    family_name = each.value["last_name"]
+  }
+  password = random_password.password.result
+}
+
+resource "null_resource" "send_password_email" {
+  for_each = { for user in googleworkspace_user.users : user.primary_email => user }
+
+  provisioner "local-exec" {
+    command = <<EOT
+      echo "Your Google Workspace account has been created. Your password is: ${googleworkspace_user.users[each.key].password}" | mail -s "Google Workspace Account Created" ${each.value["personal_email"]}
+    EOT
+  }
+}

--- a/email_groups.tf
+++ b/email_groups.tf
@@ -1,0 +1,13 @@
+resource "googleworkspace_group" "email_groups" {
+  for_each = toset(var.email_groups)
+
+  email = each.value
+}
+
+resource "googleworkspace_group_member" "group_members" {
+  for_each = { for user in googleworkspace_user.users : user.primary_email => user }
+
+  group_email = var.email_groups[0] // Example: associating with the first group
+  email       = each.value.primary_email
+  role        = "MEMBER"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,43 @@
+provider "googleworkspace" {
+  credentials = file("<path-to-service-account-key>.json")
+  customer_id = "<customer-id>"
+}
+
+resource "googleworkspace_user" "users" {
+  for_each = { for user in csvdecode(file(var.csv_file_path)) : user.personal_email => user }
+
+  primary_email = each.value.personal_email
+  name {
+    given_name  = each.value.first_name
+    family_name = each.value.last_name
+  }
+  password = random_password.password.result
+}
+
+resource "googleworkspace_group" "email_groups" {
+  for_each = toset(var.email_groups)
+
+  email = each.value
+}
+
+resource "googleworkspace_group_member" "group_members" {
+  for_each = { for user in googleworkspace_user.users : user.primary_email => user }
+
+  group_email = var.email_groups[0] // Example: associating with the first group
+  email       = each.value.primary_email
+  role        = "MEMBER"
+}
+
+resource "googleworkspace_drive" "shared_drives" {
+  for_each = toset(var.shared_drives)
+
+  name = each.value
+}
+
+resource "googleworkspace_drive_permission" "drive_permissions" {
+  for_each = { for user in googleworkspace_user.users : user.primary_email => user }
+
+  drive_id = googleworkspace_drive.shared_drives[0].id // Example: associating with the first shared drive
+  email    = each.value.primary_email
+  role     = "writer"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,11 @@
+output "created_user_accounts" {
+  value = googleworkspace_user.users
+}
+
+output "email_groups" {
+  value = googleworkspace_group.email_groups
+}
+
+output "shared_drives" {
+  value = googleworkspace_drive.shared_drives
+}

--- a/shared_drives.tf
+++ b/shared_drives.tf
@@ -1,0 +1,13 @@
+resource "googleworkspace_drive" "shared_drives" {
+  for_each = toset(var.shared_drives)
+
+  name = each.value
+}
+
+resource "googleworkspace_drive_permission" "drive_permissions" {
+  for_each = { for user in googleworkspace_user.users : user.primary_email => user }
+
+  drive_id = googleworkspace_drive.shared_drives[0].id // Example: associating with the first shared drive
+  email    = each.value.primary_email
+  role     = "writer"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,19 @@
+variable "csv_file_path" {
+  description = "Path to the CSV file containing user data"
+  type        = string
+}
+
+variable "email_groups" {
+  description = "List of email groups to associate with user accounts"
+  type        = list(string)
+}
+
+variable "shared_drives" {
+  description = "List of shared drives to manage"
+  type        = list(string)
+}
+
+variable "personal_email" {
+  description = "Personal email address to send user passwords"
+  type        = string
+}


### PR DESCRIPTION
Add Terraform code to manage Google Workspace Admin, create accounts from a CSV file, associate them with email groups, and manage shared drives.

* **README.md**: Add instructions on how to use the Terraform code, including prerequisites, usage, creating accounts from a CSV file, associating accounts with email groups, managing shared drives, and ensuring user passwords are sent only to personal email.
* **main.tf**: Add provider configuration for Google Workspace Admin, resource definitions for creating user accounts from a CSV file, associating accounts with email groups, and managing shared drives.
* **variables.tf**: Add variable definitions for necessary inputs such as CSV file path, email groups, shared drives, and personal email to send user passwords.
* **outputs.tf**: Add output definitions for created user accounts, email groups, and shared drives.
* **csv_import.tf**: Add code to read and parse the CSV file, create user accounts based on the parsed CSV data, and send user passwords to their personal email.
* **email_groups.tf**: Add code to create and manage email groups, and associate user accounts with email groups.
* **shared_drives.tf**: Add code to create and manage shared drives, and associate user accounts with shared drives.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/codaqui/terraform-organization?shareId=86add16b-7e0e-413e-b447-01bcd6e8b5db).